### PR TITLE
Introduce configuration by `TREQ_MAX_DEPTH` environment variable …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file. 
 See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.0.1"></a>
+# 1.0.1 (2022-03-30)
+
+### Features
+
+* Introduce configuration by `TREQ_MAX_DEPTH` environment variable 
+  to limit maximum depth/level to trace nested requires/imports.
+
 <a name="1.0.0"></a>
 # 1.0.0 (2022-03-29)
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,21 @@ NODE_OPTIONS=-r treq
 * **Optionally**, you can configure require duration threshold (in milliseconds) for tracing.
   Requires/imports take lower than the threshold are ignored from tracing. 
   By default, the threshold is `10` milliseconds and it can be configured by `TREQ_DURATION_THRESHOLD` environment variable.
+  For example:
+```
+TREQ_DURATION_THRESHOLD=20
+```
 
-* **Optionally**, you can disable `treq` by setting `TREQ_DISABLE` environment variable to `true`.
+* **Optionally**, you can configure maximum depth/level limit to trace nested requires/imports.
+  Nested requires/imports deeper than the maximum depth/level limit are ignored from tracing.
+  By default, the max depth is `100` and it can be configured by `TREQ_MAX_DEPTH` environment variable.
+  For example:
+```
+TREQ_MAX_DEPTH=3
+```
+
+* **Optionally**, you can disable `treq` by setting `TREQ_DISABLE` environment variable to `true`. 
+  For example:
 ```
 TREQ_DISABLE=true
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const originalRequire = Module.prototype.require;
 
 const DURATION_THRESHOLD =
     parseInt(process.env['TREQ_DURATION_THRESHOLD']) || 10;
+const MAX_DEPTH = parseInt(process.env['TREQ_MAX_DEPTH']) || 100;
 const DISABLED = process.env['TREQ_DISABLE'] === 'true';
 
 class RequireTrace {
@@ -55,7 +56,11 @@ function traceRequire(id) {
 }
 
 function dumpRequireStack(reqTrace, depth = 0) {
-    if (reqTrace.duration && reqTrace.duration >= DURATION_THRESHOLD) {
+    if (
+        reqTrace.duration &&
+        reqTrace.duration >= DURATION_THRESHOLD &&
+        depth < MAX_DEPTH
+    ) {
         let indent = '';
         for (let i = 0; i < depth; i++) {
             indent += '..';


### PR DESCRIPTION
… to limit maximum depth/level to trace nested requires/imports